### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,14 +135,4 @@ OPTIONS:
 
 ### Plugin fails with "Cannot found service: db-dumper-service"
 
-By default, the CLI plugin assumes that the associated [db-dumper-service](https://github.com/orange-cloudfoundry/db-dumper-service) backend is deployed in the marketplace as a service named `db-dumper-service`. To use the plugin with a service named differently, edit the $CF_HOME/.db-dumper file from 
-
-```json
-{"target":"db-dumper-service"}
-```
-
-into: 
-
-```json
-{"target":"<name-of-the-service-to-use>"}
-```
+By default, the CLI plugin assumes that the associated [db-dumper-service](https://github.com/orange-cloudfoundry/db-dumper-service) backend is deployed in the marketplace as a service named `db-dumper-service`. To use the plugin with a service named differently, use the `target-dump` command specifying the custom service name as argument.

--- a/README.md
+++ b/README.md
@@ -130,3 +130,19 @@ DESCRIPTION:
 OPTIONS:
     --verbose, --vvv, --vv      	Set the flag if you want to see all output from cloudfoundry cli
 ```
+
+## FAQ
+
+### Plugin fails with "Cannot found service: db-dumper-service"
+
+By default, the CLI plugin assumes that the associated [db-dumper-service](https://github.com/orange-cloudfoundry/db-dumper-service) backend is deployed in the marketplace as a service named `db-dumper-service`. To use the plugin with a service named differently, edit the $CF_HOME/.db-dumper file from 
+
+```json
+{"target":"db-dumper-service"}
+```
+
+into: 
+
+```json
+{"target":"<name-of-the-service-to-use>"}
+```


### PR DESCRIPTION
describe how to use the plugin with a backend having a customized service name (i.e. other than "db-dumper-service")